### PR TITLE
feat(chat): handle ephemeral signers for squadsx

### DIFF
--- a/components/chat/DiscussionForm.tsx
+++ b/components/chat/DiscussionForm.tsx
@@ -18,7 +18,8 @@ import { useRouteProposalQuery } from '@hooks/queries/proposal'
 import { useVotingPop } from '@components/VotePanel/hooks'
 import useLegacyConnectionContext from '@hooks/useLegacyConnectionContext'
 import { useLegacyVoterWeight } from '@hooks/queries/governancePower'
-import {useVotingClients} from "@hooks/useVotingClients";
+import { useVotingClients } from '@hooks/useVotingClients'
+import { Wallet, useWallet } from '@solana/wallet-adapter-react'
 
 const DiscussionForm = () => {
   const [comment, setComment] = useState('')
@@ -27,21 +28,22 @@ const DiscussionForm = () => {
   const realm = useRealmQuery().data?.result
   const { result: ownVoterWeight } = useLegacyVoterWeight()
   const { realmInfo } = useRealm()
-  const votingClients = useVotingClients();
+  const votingClients = useVotingClients()
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
 
   const wallet = useWalletOnePointOh()
+  const walletContext = useWallet()
   const connected = !!wallet?.connected
   const connection = useLegacyConnectionContext()
   const proposal = useRouteProposalQuery().data?.result
   const tokenRole = useVotingPop()
   const commenterVoterTokenRecord =
-    tokenRole === 'community' ? 
-      ownTokenRecord ?? ownCouncilTokenRecord : 
-      ownCouncilTokenRecord
+    tokenRole === 'community'
+      ? ownTokenRecord ?? ownCouncilTokenRecord
+      : ownCouncilTokenRecord
 
-  const votingClient = votingClients(tokenRole ?? 'community');// default to community if no role is provided
+  const votingClient = votingClients(tokenRole ?? 'community') // default to community if no role is provided
   const submitComment = async () => {
     setSubmitting(true)
     setError('')
@@ -70,6 +72,7 @@ const DiscussionForm = () => {
     try {
       await postChatMessage(
         rpcContext,
+        walletContext.wallet as Wallet,
         realm,
         proposal,
         commenterVoterTokenRecord,
@@ -81,7 +84,7 @@ const DiscussionForm = () => {
       setComment('')
     } catch (ex) {
       console.error("Can't post chat message", ex)
-      setError(ex.message);
+      setError(ex.message)
       //TODO: How do we present transaction errors to users? Just the notification?
     } finally {
       setSubmitting(false)

--- a/hooks/useSubmitVote.ts
+++ b/hooks/useSubmitVote.ts
@@ -32,9 +32,11 @@ import { useBatchedVoteDelegators } from '@components/VotePanel/useDelegators'
 import { useVotingClients } from '@hooks/useVotingClients'
 import { useNftClient } from '../VoterWeightPlugins/useNftClient'
 import { useRealmVoterWeightPlugins } from './useRealmVoterWeightPlugins'
+import { Wallet, useWallet } from '@solana/wallet-adapter-react'
 
 export const useSubmitVote = () => {
   const wallet = useWalletOnePointOh()
+  const walletContext = useWallet()
   const connection = useLegacyConnectionContext()
   const realm = useRealmQuery().data?.result
   const proposal = useRouteProposalQuery().data?.result
@@ -146,6 +148,7 @@ export const useSubmitVote = () => {
       try {
         await castVote(
           rpcContext,
+          walletContext.wallet as Wallet,
           realm,
           proposal,
           tokenOwnerRecordPk,

--- a/utils/ephemeral-signers/index.ts
+++ b/utils/ephemeral-signers/index.ts
@@ -1,0 +1,75 @@
+import { StandardWalletAdapter } from '@solana/wallet-adapter-base'
+import { Wallet } from '@solana/wallet-adapter-react'
+import { Keypair, PublicKey } from '@solana/web3.js'
+
+/**
+ * Outputs `num` number of ephemeral signers for a transaction, designed to be used only in cases
+ * where SquadsX is the connected wallet, and a throwaway keypair is signing a transaction.
+ * @arg Wallet - A standard wallet context from @solana/wallet-adapter-react
+ * @arg num - The number of ephemeral signers to generate
+ * @returns - An array of ephemeral signer PublicKeys
+ */
+export async function getEphemeralSigners(
+  wallet: Wallet,
+  num: number
+): Promise<PublicKey[]> {
+  let adapter = wallet.adapter as StandardWalletAdapter
+
+  const features = adapter.wallet.features
+
+  if (
+    adapter &&
+    'standard' in adapter &&
+    SquadsGetEphemeralSignersFeatureIdentifier in features
+  ) {
+    const ephemeralSignerFeature = (await features[
+      SquadsGetEphemeralSignersFeatureIdentifier
+    ]) as EphemeralSignerFeature
+
+    const ephemeralSigners = (await ephemeralSignerFeature.getEphemeralSigners(
+      num
+    )) as GetEphemeralSignersOutput
+
+    // WIP: Types for Solana wallet adapter features can be difficult
+    // @ts-ignore
+    return ephemeralSigners.map((signer) => new PublicKey(signer))
+  } else {
+    return [Keypair.generate().publicKey]
+  }
+}
+
+export type GetEphemeralSignersOutput = {
+  method: 'getEphemeralSigners'
+  result: {
+    ok: boolean
+    value: {
+      addresses: string[]
+    }
+  }
+}
+
+export const SquadsGetEphemeralSignersFeatureIdentifier = 'fuse:getEphemeralSigners' as const
+
+export type WalletAdapterFeature<
+  FeatureName extends string,
+  FeatureProperties extends Record<string, any> = {},
+  FeatureMethods extends Record<string, (...args: any[]) => any> = {}
+> = {
+  [K in FeatureName]: FeatureProperties &
+    {
+      [M in keyof FeatureMethods]: (
+        ...args: Parameters<FeatureMethods[M]>
+      ) => ReturnType<FeatureMethods[M]>
+    }
+}
+
+export type WalletWithEphemeralSigners = WalletAdapterFeature<
+  'standard',
+  {
+    'fuse:getEphemeralSigners': EphemeralSignerFeature
+  }
+>
+
+export type EphemeralSignerFeature = {
+  getEphemeralSigners: (num: number) => GetEphemeralSignersOutput
+}

--- a/utils/ephemeral-signers/postMessageWithEphSigner.ts
+++ b/utils/ephemeral-signers/postMessageWithEphSigner.ts
@@ -1,0 +1,142 @@
+import {
+  ChatMessageBody,
+  GOVERNANCE_CHAT_SCHEMA,
+  PostChatMessageArgs,
+  SYSTEM_PROGRAM_ID,
+  getRealmConfigAddress,
+} from '@solana/spl-governance'
+import {
+  AccountMeta,
+  Keypair,
+  PublicKey,
+  TransactionInstruction,
+} from '@solana/web3.js'
+import { serialize } from 'borsh'
+
+export async function withPostChatMessageEphSigner(
+  instructions: TransactionInstruction[],
+  signers: Keypair[],
+  chatProgramId: PublicKey,
+  governanceProgramId: PublicKey,
+  realm: PublicKey,
+  governance: PublicKey,
+  proposal: PublicKey,
+  tokenOwnerRecord: PublicKey,
+  governanceAuthority: PublicKey,
+  payer: PublicKey,
+  replyTo: PublicKey | undefined,
+  body: ChatMessageBody,
+  chatMessage: PublicKey,
+  voterWeightRecord?: PublicKey
+) {
+  const args = new PostChatMessageArgs({
+    body,
+  })
+
+  const data = Buffer.from(serialize(GOVERNANCE_CHAT_SCHEMA, args))
+
+  let keys = [
+    {
+      pubkey: governanceProgramId,
+      isWritable: false,
+      isSigner: false,
+    },
+    {
+      pubkey: realm,
+      isWritable: false,
+      isSigner: false,
+    },
+    {
+      pubkey: governance,
+      isWritable: false,
+      isSigner: false,
+    },
+    {
+      pubkey: proposal,
+      isWritable: false,
+      isSigner: false,
+    },
+    {
+      pubkey: tokenOwnerRecord,
+      isWritable: false,
+      isSigner: false,
+    },
+    {
+      pubkey: governanceAuthority,
+      isWritable: false,
+      isSigner: true,
+    },
+    {
+      pubkey: chatMessage,
+      isWritable: true,
+      isSigner: true,
+    },
+    {
+      pubkey: payer,
+      isWritable: false,
+      isSigner: true,
+    },
+    {
+      pubkey: SYSTEM_PROGRAM_ID,
+      isWritable: false,
+      isSigner: false,
+    },
+  ]
+
+  if (replyTo) {
+    keys.push({
+      pubkey: replyTo,
+      isWritable: false,
+      isSigner: false,
+    })
+  }
+
+  await withRealmConfigPluginAccounts(
+    keys,
+    governanceProgramId,
+    realm,
+    voterWeightRecord
+  )
+
+  instructions.push(
+    new TransactionInstruction({
+      keys,
+      programId: chatProgramId,
+      data,
+    })
+  )
+
+  return chatMessage
+}
+
+export async function withRealmConfigPluginAccounts(
+  keys: AccountMeta[],
+  programId: PublicKey,
+  realm: PublicKey,
+  voterWeightRecord?: PublicKey | undefined,
+  maxVoterWeightRecord?: PublicKey | undefined
+) {
+  const realmConfigAddress = await getRealmConfigAddress(programId, realm)
+
+  keys.push({
+    pubkey: realmConfigAddress,
+    isWritable: false,
+    isSigner: false,
+  })
+
+  if (voterWeightRecord) {
+    keys.push({
+      pubkey: voterWeightRecord,
+      isWritable: false,
+      isSigner: false,
+    })
+  }
+
+  if (maxVoterWeightRecord) {
+    keys.push({
+      pubkey: maxVoterWeightRecord,
+      isWritable: false,
+      isSigner: false,
+    })
+  }
+}


### PR DESCRIPTION
Overview:

Posting comments is currently blocked for SquadsX users due to the presence of ephemeral signers (one time keypairs generated for the life of a transaction). These will break transactions forwarded to the Squads UI, since the signatures are lost when transactions are compiled

This PR adds conditional handling for this case, identifying a connected SquadsX wallet and substituting the generated keypair with an ephemeral signer from the wallet adapter feature to use instead.