### PR TITLE
Update EpicentralDAO Treasury Names Metadata

### DIFF
--- a/components/instructions/tools.tsx
+++ b/components/instructions/tools.tsx
@@ -146,15 +146,19 @@ export const ACCOUNT_NAMES = {
   'LABSh5DTebUcUbEoLzXKCiXFJLecDFiDWiBGUU1GpxR': 'LABS Token Mint',
 
   'Crn54GhCKYkpoy1Mp1qZWJrzsaSbJQDR46uF5Rn4gRot': 'Main DAO Treasury',
+  '3BEvopNQ89zkM4r6ADva18i5fao1sqR1pmswyQyfj838': 'SOL Main Reserve',
   'Gh2MXR1b4CM3M5nnkoPE8Y1fpQ1H7Ujg4m8rAU2N9cCJ': 'LABS Main Vault',
 
   '5jagwdtwXufeiqn6XLxWaeCRPYT924Axyzo9ZDLAxPFC': 'Community Treasury',
+  'DR1P6yBNXQ8YLBrpYpU3FjnnruStMRzm2y2cAA3D6ynm': 'SOL Community Reserve',
   '5hYmaq1Su7fJLPAS4mKMiUq3tirR72duGGMRU2ejFMaQ': 'LABS Contributor Bonus Vault',
 
   '24Z8YUVPBSP6JHfrsy8wkGXXf1JpuA7JGfmrk2frE1zL': 'Marketing Treasury',
+  '6tpxdCf56XZQbdieLFZGDgaWpefc6SZPGy9Sg6MqYVRB': 'SOL Marketing Reserve',
   'BHjWxsNEwMCwtPWoJMsjFzjXCTgr6kbHKprGrNgLfW81': 'LABS Marketing Vault',
   
-  '9zUzsav4JcUHnmzsT9YFkbk2YvjxEf9MosVTKYDDnnnW': 'Rewards Allocation Vault',
+  '9zUzsav4JcUHnmzsT9YFkbk2YvjxEf9MosVTKYDDnnnW': 'Rewards Treasury',
+  '6yuntQAS5gSwhhKaXG3QYbcwXPxhsbULu9Tzv9mizUUm': 'SOL Rewards Reserve',
   '6PPtCuNPxipkwATrXorGNMFsEiJK2WNwNRVdgzTJZfU8': 'LABS Rewards Vault',
   
   // Physis DAO

--- a/components/instructions/tools.tsx
+++ b/components/instructions/tools.tsx
@@ -159,7 +159,7 @@ export const ACCOUNT_NAMES = {
   
   '9zUzsav4JcUHnmzsT9YFkbk2YvjxEf9MosVTKYDDnnnW': 'Rewards Treasury',
   '6yuntQAS5gSwhhKaXG3QYbcwXPxhsbULu9Tzv9mizUUm': 'SOL Rewards Reserve',
-  '6PPtCuNPxipkwATrXorGNMFsEiJK2WNwNRVdgzTJZfU8': 'LABS Rewards Vault',
+  '6PPtCuNPxipkwATrXorGNMFsEiJK2WNwNRVdgzTJZfU8': 'LABS DeFi Rewards Vault',
   
   // Physis DAO
   '29epeLvAMyRXtpA1HaoKB1hGcAnrc1NvMCbaZ8AVRwEi': 'Physis DAO Treasury',


### PR DESCRIPTION
Updated the Treasury Reserves for SOL and replaced "LABS Rewards Vault" to a more specific name: "LABS DeFi Rewards Vault"