### PR TITLE
fix .solana not parsing properly

### DIFF
--- a/pages/dao/[symbol]/proposal/components/instructions/Mint.tsx
+++ b/pages/dao/[symbol]/proposal/components/instructions/Mint.tsx
@@ -141,7 +141,9 @@ const Mint = ({
   const destinationAccountName =
     destinationAccount?.publicKey &&
     getAccountName(destinationAccount?.account.address)
-  const destinationAddressParsed = address.endsWith('.sol')
+
+  let isDomain = address.length >= 4 && address.split(".").length === 2
+  const destinationAddressParsed = isDomain
     ? form.destinationAccount
     : undefined
   const schema = getMintSchema({ form, connection })

--- a/utils/domains.ts
+++ b/utils/domains.ts
@@ -6,7 +6,7 @@ import {
   NAME_TOKENIZER_ID,
   performReverseLookupBatch,
 } from '@bonfida/spl-name-service'
-import { TldParser } from '@onsol/tldparser'
+import { splitDomainTld, TldParser } from '@onsol/tldparser'
 import { Connection, ParsedAccountData, PublicKey } from '@solana/web3.js'
 
 interface Domain {
@@ -21,8 +21,9 @@ export const resolveDomain = async (
   domainName: string
 ) => {
   try {
+    const [tld] = splitDomainTld(domainName);
     // Get the public key for the domain
-    if (domainName.includes('.sol')) {
+    if (tld === '.sol') {
       const { pubkey } = await getDomainKey(domainName)
 
       // Check if the domain is an NFT


### PR DESCRIPTION
gm, 

this is a fix for `.solana` not being able to be parsed due to it being superseded by `.sol` in the `.includes('.sol')`

also, this enables AllDomains in transfer and mint proposals as well. 

tested locally. 

regards,
miester.